### PR TITLE
Support %f as a moving clock face

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -16,7 +16,24 @@ function overrider(lbl) {
     var FORMAT = settings.get_string("override-string");
     var desired = FORMAT;
     if (FORMAT.indexOf("%") > -1) {
-        desired = GLib.DateTime.new_now_local().format(FORMAT);
+        var now = GLib.DateTime.new_now_local();
+        if (FORMAT.indexOf("%f") > -1) {
+            var hour = now.get_hour();
+            // convert from 0-23 to 1-12
+            if (hour > 12) {
+                hour -= 12;
+            }
+            if (hour == 0) {
+                hour = 12;
+            }
+            var clockFaceCodePoint = 0x1f550 + (hour - 1);
+            var minute = now.get_minute();
+            if (minute >= 30) {
+                clockFaceCodePoint += 12;
+            }
+            desired = desired.replace("%f", String.fromCodePoint(clockFaceCodePoint));
+        }
+        desired = now.format(desired);
     }
     if (t != desired) {
         last = t;


### PR DESCRIPTION
How do you feel about a moving clock face?
I've checked the docs and %f is not used by g_date_time_format(), so the overrider looks for it and replace with the appropriate clock face character.