### PR TITLE
Link to Glib’s datetime format documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Gnome Shell doesn't permit many changes to the format of its clock; in particula
 
 ![Screenshot](screenshot.png)
 
-For techies, we use the [`strftime` codes](http://strftime.org/) to specify actual times in your clock string, with a `%f` addition to mean "a little Unicode clock character" (thanks to [dsboger](https://github.com/stuartlangridge/gnome-shell-clock-override/commit/5941974a39d3dfa4f7adb227bdbe3bc50118bbc9) for that!)
+For techies, we use the [`strftime` codes](http://strftime.org/) to specify actual times in your clock string, with two additions:
+
+ * `%f`, a little Unicode clock character (thanks to [dsboger](https://github.com/stuartlangridge/gnome-shell-clock-override/commit/5941974a39d3dfa4f7adb227bdbe3bc50118bbc9) for that!
+ * `%@`, internet time (.beat)
 
 Note that we still try to honour Gnome Shell's clock settings. So if you expect your clock to show seconds (or to update once a second, rather than once a minute) then you'll need to have turned on "show seconds" in Gnome Tweak Tool (under Top Bar) (or [the terminal way](https://askubuntu.com/questions/39412/how-to-show-seconds-on-the-clock-in-gnome-3)).

--- a/extension.js
+++ b/extension.js
@@ -53,6 +53,8 @@ function overrider(lbl) {
     var desired = FORMAT;
     if (FORMAT.indexOf("%") > -1) {
         var now = GLib.DateTime.new_now_local();
+        var utcnow = GLib.DateTime.new_now_utc();
+
         if (FORMAT.indexOf("%f") > -1) {
             var hour = now.get_hour();
             // convert from 0-23 to 1-12
@@ -75,6 +77,12 @@ function overrider(lbl) {
             }
             desired = desired.replace("%f", repl);
         }
+        if (FORMAT.indexOf("%@") > -1) {
+            var beat_time = 0 | (((utcnow.get_hour() + 1) % 24) + utcnow.get_minute() / 60 + utcnow.get_second() / 3600) * 1000 / 24;
+            beat_time = ('000' + beat_time).slice(-3);
+            desired = desired.replace("%@", beat_time);
+        }
+
         desired = now.format(desired);
     }
     if (t != desired) {

--- a/prefs.js
+++ b/prefs.js
@@ -15,8 +15,9 @@ const EXAMPLES = [
     ["The time as HH.MM", "%H.%M"],
     ["The time in 24-hour notation (7:30:00 am BST)", "%r"],
     ["A bell", "🔔"],
-    ["A clock", "%f"],
+    ["An analog clock", "%f"],
     ["ISO date and time (2014-01-30T04:27:00)", "%FT%T"],
+    ["Local and Internet time", "%H:%M @%@"],
     ["Something sillier", "It is %M minutes past hour %H"]
 ];
 
@@ -31,7 +32,7 @@ const ClockOverrideSettings = new GObject.Class({
             this._settings.set_string('override-string', value);
 
             var set_clock_seconds;
-            if ((value.indexOf("%S") !== -1) || (value.indexOf("%-S") !== -1) || (value.indexOf("%r") !== -1) || (value.indexOf("%T") !== -1)) {
+            if ((value.indexOf("%S") !== -1) || (value.indexOf("%-S") !== -1) || (value.indexOf("%r") !== -1) || (value.indexOf("%T") !== -1) || (value.indexOf("%@") !== -1)) {
                 // requested time has seconds in it, so the clock needs to be updated every second
                 set_clock_seconds = true;
             } else {


### PR DESCRIPTION
Python’s strftime directives aren’t the same as C’s directives. Glib supports some GNU extensions but doesn’t support everything from C. I believe this document is the only place that will document GLib.DateTime.Format’s exact capabilities.