### PR TITLE
Allow multiple `%f` instances in override format

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -73,7 +73,7 @@ function overrider(lbl) {
             } else {
                 repl = fromCodePoint(clockFaceCodePoint);
             }
-            desired = desired.replace("%f", repl);
+            desired = desired.replace(/%f/g, repl);
         }
         desired = now.format(desired);
     }


### PR DESCRIPTION
I wanted to use it as a kind of separator, but couldn't.