### PR TITLE
Adding tab code %;tf

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -54,6 +54,9 @@ function overrider(lbl) {
     var now = GLib.DateTime.new_now_local();
 
     if (FORMAT.indexOf("%;") > -1) {
+	if (FORMAT.indexOf("%;tf") > -1) {
+    	    desired = desired.replace(/%;tf/g, '\t');
+	}
         if (FORMAT.indexOf("%;vf") > -1) {
             var quarters = Math.round(now.get_minute() / 15);
             var vulgar_fraction = ["\u2070/\u2080", "\u00B9/\u2084", "\u00B9/\u2082", "\u00B3/\u2084", "\u00B9/\u2081"][quarters];


### PR DESCRIPTION
Adding a code to insert tab.

At the end of the expression, it avoids the clock, when centered on the top bar, to slightly move with non-monospace fonts (i.e. when last digit goes from 0 to 1, from 1 to 2, etc… really annoying when displaying seconds).
It also allows for more rendering customization, hence the code instead of systematically insert a tab at the end of every expression.