### PR TITLE
Slow time with natural language

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ all: build
 .PHONY: build
 build: locale/clock-override.pot $(distfiles)
 
-locale/clock-override.pot: prefs.js
+locale/clock-override.pot: format.js prefs.js
 	xgettext --from-code=UTF-8 -k_ -kN_ -o $@ $?
 
 %.mo: %.po

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ For techies, we use the [`GLib GDateTime` codes](https://developer.gnome.org/gli
 
  * `%;cf`, a little emoji Unicode clock face (thanks to [dsboger](https://github.com/stuartlangridge/gnome-shell-clock-override/commit/5941974a39d3dfa4f7adb227bdbe3bc50118bbc9) for that!)
  * `%;vf`, quarters as vulgar fractions
+ * `%;nf`, quarters in natural language
  * `%;@`, internet time (.beat)
 
 Note that we still try to honour Gnome Shell's clock settings. So if you expect your clock to show seconds (or to update once a second, rather than once a minute) then you'll need to have turned on "show seconds" in Gnome Tweak Tool (under Top Bar) (or [the terminal way](https://askubuntu.com/questions/39412/how-to-show-seconds-on-the-clock-in-gnome-3)).

--- a/format.js
+++ b/format.js
@@ -45,6 +45,20 @@ function format(FORMAT, now) {
             var vulgar_fraction = ["\u2070/\u2080", "\u00B9/\u2084", "\u00B9/\u2082", "\u00B3/\u2084", "\u00B9/\u2081"][quarters];
             desired = desired.replace(/%;vf/g, vulgar_fraction);
         }
+        if (FORMAT.indexOf("%;nf") > -1) {
+            var hour = now.get_hour();
+            var quarters = Math.round(now.get_minute() / 15);
+            
+            var natural_language = [
+                _("%H o'clock"),
+                _("quarter past %H"),
+                _("half past %H"),
+                _("quarter to %;nH"),
+                _("%;nH o'clock")
+            ][quarters];
+            natural_language = natural_language.replace(/%;nH/, hour + 1);
+            desired = desired.replace(/%;nf/g, natural_language);
+        }
         if (FORMAT.indexOf("%;cf") > -1) {
             var hour = now.get_hour();
             // convert from 0-23 to 1-12

--- a/locale/clock-override.pot
+++ b/locale/clock-override.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-15 18:48+0200\n"
+"POT-Creation-Date: 2019-02-17 12:14+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,26 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: format.js:53
+msgid "%H o'clock"
+msgstr ""
+
+#: format.js:54
+msgid "quarter past %H"
+msgstr ""
+
+#: format.js:55
+msgid "half past %H"
+msgstr ""
+
+#: format.js:56
+msgid "quarter to %;nH"
+msgstr ""
+
+#: format.js:57
+msgid "%;nH o'clock"
+msgstr ""
 
 #: prefs.js:51
 msgid "Text to display instead of the clock"
@@ -46,22 +66,26 @@ msgid "Slow time (quarters as fractions)"
 msgstr ""
 
 #: prefs.js:83
-msgid "ISO date and time (2014-01-30T14:50:10)"
+msgid "Slow time (quarters in natural language)"
 msgstr ""
 
 #: prefs.js:84
+msgid "ISO date and time (2014-01-30T14:50:10)"
+msgstr ""
+
+#: prefs.js:85
 msgid "Local and Internet time"
 msgstr ""
 
-#: prefs.js:85
+#: prefs.js:86
 msgid "Something sillier"
 msgstr ""
 
-#: prefs.js:85
+#: prefs.js:86
 msgid "It is %M minutes past hour %H"
 msgstr ""
 
-#: prefs.js:120
+#: prefs.js:121
 #, javascript-format
 msgid "What do all these %x codes mean?"
 msgstr ""

--- a/locale/de/LC_MESSAGES/clock-override.po
+++ b/locale/de/LC_MESSAGES/clock-override.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Extension Clock Override\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-20 18:26+0200\n"
+"POT-Creation-Date: 2019-02-17 12:14+0100\n"
 "PO-Revision-Date: 2018-08-15 18:36+0200\n"
 "Last-Translator: Jonatan Hatakeyama Zeidler <jonatan_zeidler@gmx.de>\n"
 "Language-Team: Jonatan H. Zeidler, Matthäus Brandl\n"
@@ -19,6 +19,25 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: format.js:53
+msgid "%H o'clock"
+msgstr ""
+
+#: format.js:54
+msgid "quarter past %H"
+msgstr ""
+
+#: format.js:55
+msgid "half past %H"
+msgstr ""
+
+#: format.js:56
+msgid "quarter to %;nH"
+msgstr ""
+
+#: format.js:57
+msgid "%;nH o'clock"
+msgstr ""
 
 #: prefs.js:51
 msgid "Text to display instead of the clock"
@@ -49,23 +68,27 @@ msgid "Slow time (quarters as fractions)"
 msgstr "Slow-Zeit (Viertelstunden als Brüche)"
 
 #: prefs.js:83
+msgid "Slow time (quarters in natural language)"
+msgstr ""
+
+#: prefs.js:84
 msgid "ISO date and time (2014-01-30T14:50:10)"
 msgstr "Datum und Zeit nach ISO (2014-01-30T14:50:10)"
 
-#: prefs.js:84
+#: prefs.js:85
 msgid "Local and Internet time"
 msgstr "Ortszeit und Internetzeit"
 
-#: prefs.js:85
 # In this context silly seems to convey a notion of funny instead of stupid. Hence "albern" instead of "dumm".
+#: prefs.js:86
 msgid "Something sillier"
 msgstr "Etwas Alberneres"
 
-#: prefs.js:85
+#: prefs.js:86
 msgid "It is %M minutes past hour %H"
 msgstr "Es ist %M Minuten nach %H Uhr"
 
-#: prefs.js:120
+#: prefs.js:121
 #, javascript-format
 msgid "What do all these %x codes mean?"
 msgstr "Was bedeuten all diese Codes mit %x?"

--- a/locale/es/LC_MESSAGES/clock-override.po
+++ b/locale/es/LC_MESSAGES/clock-override.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Extension Clock Override\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-15 18:48+0200\n"
+"POT-Creation-Date: 2019-02-17 12:14+0100\n"
 "PO-Revision-Date: 2018-08-04 11:10+0200\n"
 "Last-Translator: Luis Zurro <https://pistachitos.com>\n"
 "Language-Team: Luis Zurro\n"
@@ -17,6 +17,26 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "\n"
+
+#: format.js:53
+msgid "%H o'clock"
+msgstr ""
+
+#: format.js:54
+msgid "quarter past %H"
+msgstr ""
+
+#: format.js:55
+msgid "half past %H"
+msgstr ""
+
+#: format.js:56
+msgid "quarter to %;nH"
+msgstr ""
+
+#: format.js:57
+msgid "%;nH o'clock"
+msgstr ""
 
 #: prefs.js:51
 msgid "Text to display instead of the clock"
@@ -47,22 +67,26 @@ msgid "Slow time (quarters as fractions)"
 msgstr "Tiempo lento (cuartos como fracciones)"
 
 #: prefs.js:83
+msgid "Slow time (quarters in natural language)"
+msgstr ""
+
+#: prefs.js:84
 msgid "ISO date and time (2014-01-30T14:50:10)"
 msgstr "Fecha y hora ISO (2014-01-30T04:27:00)"
 
-#: prefs.js:84
+#: prefs.js:85
 msgid "Local and Internet time"
 msgstr "Tiempo local y de Internet"
 
-#: prefs.js:85
+#: prefs.js:86
 msgid "Something sillier"
 msgstr "Algo ridículo"
 
-#: prefs.js:85
+#: prefs.js:86
 msgid "It is %M minutes past hour %H"
 msgstr "Son las %H y %M minutos"
 
-#: prefs.js:120
+#: prefs.js:121
 #, javascript-format
 msgid "What do all these %x codes mean?"
 msgstr "¿Qué significan todos los códigos %x?"

--- a/locale/fr/LC_MESSAGES/clock-override.po
+++ b/locale/fr/LC_MESSAGES/clock-override.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Extension Clock Override\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-15 18:48+0200\n"
+"POT-Creation-Date: 2019-02-17 12:14+0100\n"
 "PO-Revision-Date: 2019-01-27 18:12+0200\n"
 "Last-Translator: Kariiboo <https://github.com/Kariiboo>\n"
 "Language-Team: Kariiboo\n"
@@ -16,6 +16,26 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: format.js:53
+msgid "%H o'clock"
+msgstr ""
+
+#: format.js:54
+msgid "quarter past %H"
+msgstr ""
+
+#: format.js:55
+msgid "half past %H"
+msgstr ""
+
+#: format.js:56
+msgid "quarter to %;nH"
+msgstr ""
+
+#: format.js:57
+msgid "%;nH o'clock"
+msgstr ""
 
 #: prefs.js:51
 msgid "Text to display instead of the clock"
@@ -46,22 +66,26 @@ msgid "Slow time (quarters as fractions)"
 msgstr "Heure approximative (par quart d'heure)"
 
 #: prefs.js:83
+msgid "Slow time (quarters in natural language)"
+msgstr ""
+
+#: prefs.js:84
 msgid "ISO date and time (2014-01-30T14:50:10)"
 msgstr "Date et heure au format ISO (2014-01-30T14:50:10)"
 
-#: prefs.js:84
+#: prefs.js:85
 msgid "Local and Internet time"
 msgstr "Heure locale et Internet"
 
-#: prefs.js:85
+#: prefs.js:86
 msgid "Something sillier"
 msgstr "Quelque chose de plus stupide"
 
-#: prefs.js:85
+#: prefs.js:86
 msgid "It is %M minutes past hour %H"
 msgstr "Il est %H et %M minutes"
 
-#: prefs.js:120
+#: prefs.js:121
 #, javascript-format
 msgid "What do all these %x codes mean?"
 msgstr "Que signifient ces codes %x ?"

--- a/locale/nb/LC_MESSAGES/clock-override.po
+++ b/locale/nb/LC_MESSAGES/clock-override.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Extension Clock Override\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-07 21:42+0200\n"
+"POT-Creation-Date: 2019-02-17 12:14+0100\n"
 "PO-Revision-Date: 2018-08-06 15:09+0200\n"
 "Last-Translator: Daniel Aleksandersen <https://www.daniel.priv.no>\n"
 "Language-Team: Daniel Aleksandersen\n"
@@ -17,6 +17,26 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.0.1\n"
 "X-Poedit-SourceCharset: UTF-8\n"
+
+#: format.js:53
+msgid "%H o'clock"
+msgstr ""
+
+#: format.js:54
+msgid "quarter past %H"
+msgstr ""
+
+#: format.js:55
+msgid "half past %H"
+msgstr ""
+
+#: format.js:56
+msgid "quarter to %;nH"
+msgstr ""
+
+#: format.js:57
+msgid "%;nH o'clock"
+msgstr ""
 
 #: prefs.js:51
 msgid "Text to display instead of the clock"
@@ -47,22 +67,26 @@ msgid "Slow time (quarters as fractions)"
 msgstr "Treg tid (kvarater som brøk)"
 
 #: prefs.js:83
+msgid "Slow time (quarters in natural language)"
+msgstr ""
+
+#: prefs.js:84
 msgid "ISO date and time (2014-01-30T14:50:10)"
 msgstr "ISO dato- og tidsformat (2014-01-30T14:50:10)"
 
-#: prefs.js:84
+#: prefs.js:85
 msgid "Local and Internet time"
 msgstr "Lokal og internettid"
 
-#: prefs.js:85
+#: prefs.js:86
 msgid "Something sillier"
 msgstr "Noe litt snålere"
 
-#: prefs.js:85
+#: prefs.js:86
 msgid "It is %M minutes past hour %H"
 msgstr "Klokken er %M minutter over %H"
 
-#: prefs.js:120
+#: prefs.js:121
 #, javascript-format
 msgid "What do all these %x codes mean?"
 msgstr "Hva betyr disse %x-kodene?"

--- a/locale/pt/LC_MESSAGES/clock-override.po
+++ b/locale/pt/LC_MESSAGES/clock-override.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GNOME Shell Extension Clock Override\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-15 18:48+0200\n"
+"POT-Creation-Date: 2019-02-17 12:14+0100\n"
 "PO-Revision-Date: 2018-10-29 04:00+0000\n"
 "Last-Translator: Isabelle Porto\n"
 "Language-Team: Isabelle Porto\n"
@@ -16,6 +16,26 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: format.js:53
+msgid "%H o'clock"
+msgstr ""
+
+#: format.js:54
+msgid "quarter past %H"
+msgstr ""
+
+#: format.js:55
+msgid "half past %H"
+msgstr ""
+
+#: format.js:56
+msgid "quarter to %;nH"
+msgstr ""
+
+#: format.js:57
+msgid "%;nH o'clock"
+msgstr ""
 
 #: prefs.js:51
 msgid "Text to display instead of the clock"
@@ -46,22 +66,26 @@ msgid "Slow time (quarters as fractions)"
 msgstr "Tempo lento (quartos como frações)"
 
 #: prefs.js:83
+msgid "Slow time (quarters in natural language)"
+msgstr ""
+
+#: prefs.js:84
 msgid "ISO date and time (2014-01-30T14:50:10)"
 msgstr "Data e hora no formato ISO (2014-01-30T14:50:10)"
 
-#: prefs.js:84
+#: prefs.js:85
 msgid "Local and Internet time"
 msgstr "Horário local e da Internet"
 
-#: prefs.js:85
+#: prefs.js:86
 msgid "Something sillier"
 msgstr "Algo mais bobo"
 
-#: prefs.js:85
+#: prefs.js:86
 msgid "It is %M minutes past hour %H"
 msgstr "São %M minutos depois das %H"
 
-#: prefs.js:120
+#: prefs.js:121
 #, javascript-format
 msgid "What do all these %x codes mean?"
 msgstr "O que todos esses códigos %x significam?"

--- a/prefs.js
+++ b/prefs.js
@@ -80,6 +80,7 @@ const ClockOverrideSettings = new GObject.Class({
             [_("A bell"), "🔔"],
             [_("An emoji clock face"), "%;cf"],
             [_("Slow time (quarters as fractions)"), "%H %;vf"],
+            [_("Slow time (quarters in natural language)"), "%;nf"],
             [_("ISO date and time (2014-01-30T14:50:10)"), "%FT%T"],
             [_("Local and Internet time"), "%H:%M @%;@."],
             [_("Something sillier"), _("It is %M minutes past hour %H")]


### PR DESCRIPTION
Adds an option for slow time using natural language. This is roughly based on the idea of @Cj-Malone in https://github.com/stuartlangridge/gnome-shell-clock-override/issues/6.

I'm unsure about the locale changes with translations from format.js as I had some trouble building these translations in the .po files. Please let me know if this is not correctly done!