### PR TITLE
update preference examples to include new line

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -78,6 +78,7 @@ const ClockOverrideSettings = new GObject.Class({
             [_("The time in 24-hour notation (14:50)"), "%H:%M"],
             [_("The time in 12-hour notation with seconds (2:50:10 pm)"), "%r"],
             [_("A bell"), "🔔"],
+            [_("A new line"), "%n"],
             [_("An emoji clock face"), "%;cf"],
             [_("Slow time (quarters as fractions)"), "%H %;vf"],
             [_("ISO date and time (2014-01-30T14:50:10)"), "%FT%T"],


### PR DESCRIPTION
There is a feature wanted for whom needs to create a two line/multi-line clock, for example this: #34 

Since the feature is already here, but no documented (not even in the developers.gnome.org link), I just find it when I saw the issue above so the users commented the use of `%n`.

Thanks!