### PR TITLE
Keep the text align even with multi-line clock

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -35,6 +35,8 @@ function enable() {
         print("Looks like Shell has changed where things live again; aborting.");
         return;
     }
+    
+    sA.dateMenu.actor.set_style("text-align: center;");
 
     sA.dateMenu.actor.first_child.get_children().forEach(function(w) {
         // assume that the text label is the first StLabel we find.


### PR DESCRIPTION
When using a multi-line `%n`, the text won't be align at the center like this:
![image](https://user-images.githubusercontent.com/11244067/89108337-f8ad6d00-d40d-11ea-9356-77cec9df8bdb.png)

with `text-align: center` (this PR):
![image](https://user-images.githubusercontent.com/11244067/89108358-28f50b80-d40e-11ea-927f-34f2b0669b0b.png)
