### PR TITLE
add one single digit hour/day/month without space

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,15 @@ Gnome Shell doesn't permit many changes to the format of its clock; in particula
 
 ![Extension screenshot](assets/screenshot.png)
 
-For techies, we use the [`GLib GDateTime` codes](https://developer.gnome.org/glib/stable/glib-GDateTime.html#g-date-time-format) to specify actual times in your clock string, with three additions:
+For techies, we use the [`GLib GDateTime` codes](https://developer.gnome.org/glib/stable/glib-GDateTime.html#g-date-time-format) to specify actual times in your clock string, with seven additions:
 
  * `%;cf`, a little emoji Unicode clock face (thanks to [dsboger](https://github.com/stuartlangridge/gnome-shell-clock-override/commit/5941974a39d3dfa4f7adb227bdbe3bc50118bbc9) for that!)
  * `%;vf`, quarters as vulgar fractions
  * `%;@`, internet time (.beat)
  * `%n`, line breaks
+ * `%;l`, same as %l but without being preceded by a blank
+ * `%;e`, same as %e but without being preceded by a blank
+ * `%;m`, same as %m but without being preceded by a blank
 
 Note that we still try to honour Gnome Shell's clock settings. So if you expect your clock to show seconds (or to update once a second, rather than once a minute) then you'll need to have turned on "show seconds" in Gnome Tweak Tool (under Top Bar) (or [the terminal way](https://askubuntu.com/questions/39412/how-to-show-seconds-on-the-clock-in-gnome-3)).
 

--- a/formatter.js
+++ b/formatter.js
@@ -67,6 +67,27 @@ function format(FORMAT, now) {
             }
             desired = desired.replace(/%;cf/g, repl);
         }
+        if (FORMAT.indexOf("%;l") > -1) {
+            var hour = now.get_hour();
+            // convert from 0-23 to 1-12
+            if (hour > 12) {
+                hour -= 12;
+            }
+            if (hour == 0) {
+                hour = 12;
+            }
+            desired = desired.replace(/%;l/g, hour);
+        }
+        if (FORMAT.indexOf("%;e") > -1) {
+            var day = now.get_day_of_month();
+
+            desired = desired.replace(/%;e/g, day);
+        }
+        if (FORMAT.indexOf("%;m") > -1) {
+            var month = now.get_month();
+
+            desired = desired.replace(/%;m/g, month);
+        }
         if (FORMAT.indexOf("%;@") > -1) {
             var bmtnow = now.to_timezone(GLib.TimeZone.new('+01'));
             var beat_time = 0 | (bmtnow.get_hour() + (bmtnow.get_minute() / 60) + bmtnow.get_second() / 3600) * 1000 / 24;


### PR DESCRIPTION
Thanks to have accepted my last pull request to align the clock on multiple lines.

A thing i figured out when configuring my clock now aligned was the missing formats for one single digit hour/day/month without being preceded by a blank.

So I have added these three:
 * `%;l`, same as %l but without being preceded by a blank
 * `%;e`, same as %e but without being preceded by a blank
 * `%;m`, same as %m but without being preceded by a blank

Thanks again,