### PR TITLE
fix: on first run of gnome-shell its not centered

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -35,13 +35,12 @@ function enable() {
         print("Looks like Shell has changed where things live again; aborting.");
         return;
     }
-    
-    sA.dateMenu.actor.set_style("text-align: center;");
 
     sA.dateMenu.actor.first_child.get_children().forEach(function(w) {
         // assume that the text label is the first StLabel we find.
         // This is dodgy behaviour but there's no reliable way to
         // work out which it is.
+        w.set_style("text-align: center;");
         if (w.get_text && !lbl) { lbl = w; }
     });
     if (!lbl) {


### PR DESCRIPTION
I find out that it wasn't centering the text (#46) when I started the gnome shell for the first time, just when the shell was restarted.

The reason for that was: I was applying the style to `sA.dateMenu.actor` but I should have applied it on its children instead.

Sorry about that, sending the fix.

Thanks