### PR TITLE
Add version "40.0" to metadata.json

### DIFF
--- a/metadata.json.in
+++ b/metadata.json.in
@@ -3,7 +3,8 @@
   "description": "Customize the date and time format displayed in clock in the top bar in GNOME Shell. Add as much or as little time information you want with extensive formatting options including an emoji clock face and Internet Time (.beat).",
   "shell-version": [
     "3.18",
-    "3.28"
+    "3.28",
+    "40.0"
   ],
   "settings-schema": "org.gnome.shell.extensions.clock-override",
   "url": "https://github.com/stuartlangridge/gnome-shell-clock-override",


### PR DESCRIPTION
This is all that's required to make the extension work in GNOME 3.40. I guess GNOME version number reporting changed? And GNOME doesn't attempt to load extensions that don't explicitly list the right version in their metadata?