### PR TITLE
Eliminate deprecated '.actor' references

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -31,12 +31,12 @@ function enable() {
     var sA = Main.panel._statusArea;
     if (!sA) { sA = Main.panel.statusArea; }
 
-    if (!sA || !sA.dateMenu || !sA.dateMenu.actor) {
+    if (!sA || !sA.dateMenu) {
         print("Looks like Shell has changed where things live again; aborting.");
         return;
     }
 
-    sA.dateMenu.actor.first_child.get_children().forEach(function(w) {
+    sA.dateMenu.first_child.get_children().forEach(function(w) {
         // assume that the text label is the first StLabel we find.
         // This is dodgy behaviour but there's no reliable way to
         // work out which it is.


### PR DESCRIPTION
This object used to have an '.actor' property but is now instead a subclass of Actor so you can operate directly on them. See https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/757e766a111d2babb0a693e6a07b2d06ab0499ae/js/ui/environment.js#L364

Fix for warning on startup:
Usage of object.actor is deprecated for DateMenuButton
get@resource:///org/gnome/shell/ui/environment.js:317:29
enable@/home/david/.local/share/gnome-shell/extensions/clock-override@gnomeshell.kryogenix.org/extension.js:34:32
...