### PR TITLE
Compatibility with GTK4.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,7 @@ distclean:
 
 .PHONY: install
 install: dist
-	-mkdir -p $(PREFIX)/$(UUID)
-	-rm -rf $(PREFIX)/$(UUID)/*
-	cp "${DISTNAME}.zip" $(PREFIX)/$(UUID)
-	cd $(PREFIX)/$(UUID) && unzip -o "${DISTNAME}.zip" && rm "${DISTNAME}.zip"
-	-gnome-shell-extension-tool --reload-extension="$(UUID)"
+	gnome-extension install "${DISTNAME}.zip"
 
 .PHONY: test
 test:

--- a/metadata.json.in
+++ b/metadata.json.in
@@ -2,8 +2,9 @@
   "name": "%_NAME_%",
   "description": "Customize the date and time format displayed in clock in the top bar in GNOME Shell. Add as much or as little time information you want with extensive formatting options including an emoji clock face and Internet Time (.beat).",
   "shell-version": [
-    "3.18",
-    "3.28"
+	 "40",
+	 "41",
+	 "42"
   ],
   "settings-schema": "org.gnome.shell.extensions.clock-override",
   "url": "https://github.com/stuartlangridge/gnome-shell-clock-override",

--- a/prefs.js
+++ b/prefs.js
@@ -93,26 +93,23 @@ const ClockOverrideSettings = new GObject.Class({
             /* It would be nicer to use just a Label with a hyperlink in it here, for accessibility
                reasons, but god alone knows how to remove the underline on a label, thanks to the
                lack of Gtk CSS examples. And a Button would be ugly. So an EventBox it is for now. */
-            let eb = new Gtk.EventBox({
-                hexpand: true,
-                halign: Gtk.Align.START
-            });
+            let event_controller = new Gtk.EventControllerKey();
+            event_controller.connect('key-pressed', Lang.bind(grid, function(w) {
+                this.update_textbox_value(eg[1]);
+                grid._settings.set_string('override-string', eg[1]);
+                return true;
+				}));
             let r = new Gtk.Label({
                 label: '<tt>' + eg[1] + '</tt>',
                 use_markup: true,
                 hexpand: true,
                 halign: Gtk.Align.START
             });
-            eb.add(r);
-            eb.connect("button-press-event", Lang.bind(grid, function(w) {
-                this.update_textbox_value(eg[1]);
-                grid._settings.set_string('override-string', eg[1]);
-                return true;
-            }));
+            r.add_controller(event_controller);
             r.get_style_context().add_provider(css, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
 
             grid.attach(l, 0, rownumber, 1, 1);
-            grid.attach(eb, 1, rownumber, 2, 1);
+            grid.attach(r, 1, rownumber, 2, 1);
             rownumber += 1;
         });
 
@@ -136,7 +133,7 @@ const ClockOverrideSettings = new GObject.Class({
 
 function buildPrefsWidget() {
      let widget = new ClockOverrideSettings();
-     widget.show_all();
+     widget.show();
 
      return widget;
 }


### PR DESCRIPTION
In order to make this extension compatible with GNOME 4X and GTK4,

1. the call to the deprecated `gnome-shell-extension-tool` removed in favour of a call to its replacement `gnome-extensions`,
2. the deprecated Gtk.EventBox was removed in favour of adding an even controller to the label itself,
3. the call to the deprecated method Grid.show_all() was replaced by a call to Grid.show(), and
4. the list of supported versions in the metadata.json was modified.